### PR TITLE
feat: Update default board size to 4x4 (JPA-19)

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,15 +1,15 @@
 // Game Configuration
 export const GAME_CONFIG = {
   BOARD_SIZE: {
-    CLASSIC: 9,
+    CLASSIC: 16,
     GIANT: 25,
     ULTIMATE: 81
   },
   WINNING_LINES: {
     CLASSIC: [
-      [0, 1, 2], [3, 4, 5], [6, 7, 8], // Rows
-      [0, 3, 6], [1, 4, 7], [2, 5, 8], // Columns
-      [0, 4, 8], [2, 4, 6]             // Diagonals
+      [0, 1, 2, 3], [4, 5, 6, 7], [8, 9, 10, 11], [12, 13, 14, 15], // Rows
+      [0, 4, 8, 12], [1, 5, 9, 13], [2, 6, 10, 14], [3, 7, 11, 15], // Columns
+      [0, 5, 10, 15], [3, 6, 9, 12]                                   // Diagonals
     ],
     GIANT: [
       // Rows


### PR DESCRIPTION
## Summary
This PR implements the requested change in JPA-19 to make the default board 4x4 instead of 3x3.

## Changes Made
- **BOARD_SIZE.CLASSIC**: Updated from `9` to `16` (3x3 → 4x4)
- **WINNING_LINES.CLASSIC**: Completely updated winning patterns for 4x4 board:
  - 4 rows: `[0,1,2,3]`, `[4,5,6,7]`, `[8,9,10,11]`, `[12,13,14,15]`
  - 4 columns: `[0,4,8,12]`, `[1,5,9,13]`, `[2,6,10,14]`, `[3,7,11,15]`
  - 2 diagonals: `[0,5,10,15]`, `[3,6,9,12]`

## Board Layout (4x4)
```
 0 |  1 |  2 |  3
---|----|----|----
 4 |  5 |  6 |  7  
---|----|----|----
 8 |  9 | 10 | 11
---|----|----|----
12 | 13 | 14 | 15
```

## Backward Compatibility
- GIANT (5x5) and ULTIMATE (9x9) modes remain unchanged
- All other constants and configurations preserved

## Related
- Jira Issue: JPA-19
- This change affects game engine and frontend repositories