### PR TITLE
Add player color selection support to shared types

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,3 +1,17 @@
+import { PlayerColor } from './types';
+
+// Player Color Configuration
+export const PLAYER_COLORS: Record<PlayerColor, { name: string; hex: string; rgb: string }> = {
+  red: { name: 'Red', hex: '#FF4444', rgb: 'rgb(255, 68, 68)' },
+  blue: { name: 'Blue', hex: '#4444FF', rgb: 'rgb(68, 68, 255)' },
+  green: { name: 'Green', hex: '#44FF44', rgb: 'rgb(68, 255, 68)' },
+  yellow: { name: 'Yellow', hex: '#FFFF44', rgb: 'rgb(255, 255, 68)' },
+  purple: { name: 'Purple', hex: '#FF44FF', rgb: 'rgb(255, 68, 255)' },
+  orange: { name: 'Orange', hex: '#FF8844', rgb: 'rgb(255, 136, 68)' }
+};
+
+export const DEFAULT_PLAYER_COLORS: PlayerColor[] = ['red', 'blue'];
+
 // Game Configuration
 export const GAME_CONFIG = {
   BOARD_SIZE: {
@@ -159,4 +173,4 @@ export const UI_CONFIG = {
     LG: 1024,
     XL: 1280
   }
-} as const; 
+} as const;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,6 @@
 // Player and Game State Types
 export type Player = 'X' | 'O';
+export type PlayerColor = 'red' | 'blue' | 'green' | 'yellow' | 'purple' | 'orange';
 export type Cell = Player | null;
 export type Board = Cell[];
 
@@ -20,6 +21,7 @@ export interface GamePlayer {
   id: string;
   name: string;
   symbol: Player;
+  color: PlayerColor;
   isReady: boolean;
   score: number;
 }
@@ -70,6 +72,7 @@ export interface SocketEvents {
   'make-move': (gameId: string, position: number) => void;
   'player-ready': (gameId: string) => void;
   'start-game': (gameId: string) => void;
+  'select-color': (gameId: string, color: PlayerColor) => void;
   'send-message': (roomId: string, message: ChatMessage) => void;
   
   // Server to Client
@@ -80,6 +83,7 @@ export interface SocketEvents {
   'move-made': (move: GameMove, gameState: GameState) => void;
   'player-joined': (player: GamePlayer) => void;
   'player-left': (playerId: string) => void;
+  'color-selected': (playerId: string, color: PlayerColor) => void;
   'game-started': (gameState: GameState) => void;
   'game-ended': (gameState: GameState, stats: GameStats) => void;
   'message-received': (message: ChatMessage) => void;
@@ -165,4 +169,4 @@ export type DeepPartial<T> = {
   [P in keyof T]?: T[P] extends object ? DeepPartial<T[P]> : T[P];
 };
 
-export type RequiredKeys<T, K extends keyof T> = T & Required<Pick<T, K>>; 
+export type RequiredKeys<T, K extends keyof T> = T & Required<Pick<T, K>>;


### PR DESCRIPTION
## Summary
Implements foundational type definitions for player color selection feature as part of **WTB-1: Allow players to select their color in tic tac toe**.

## Changes Made

### New Types
- **`PlayerColor`**: Union type with 6 color options (`red`, `blue`, `green`, `yellow`, `purple`, `orange`)
- **`GamePlayer.color`**: Added color field to track each player's selected color

### Socket Events
- **`select-color`**: Client event for players to choose their color
- **`color-selected`**: Server event to broadcast color selection to other players

### Constants
- **`PLAYER_COLORS`**: Color configuration with name, hex, and RGB values for each color
- **`DEFAULT_PLAYER_COLORS`**: Default colors assigned to new players (`['red', 'blue']`)

## Technical Details
- Maintains backward compatibility with existing `Player` symbol system (`'X'` | `'O'`)
- Color selection is separate from game symbols, allowing visual customization
- Type-safe color definitions ensure consistency across all services

## Dependencies
This change provides the foundation for:
- Game engine logic to handle color assignments
- Frontend UI for color selection
- Backend socket handling for color events
- Database storage of player color preferences

## Related Issues
- **WTB-1**: Allow players to select their color in tic tac toe

## Next Steps
After this PR is merged, the following repositories will be updated:
1. `tic-tac-toe-game-engine` - Add color assignment logic
2. `tic-tac-toe-backend` - Implement color selection socket handlers
3. `tic-tac-toe-frontend` - Create color selection UI
4. `tic-tac-toe-database-service` - Store player color preferences