### PR TITLE
feat: Add player color selection types and constants for WTB-1

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,3 +1,19 @@
+// Player colors available for selection
+export const PLAYER_COLORS = {
+  RED: '#FF6B6B',
+  BLUE: '#4ECDC4',
+  GREEN: '#45B7D1',
+  PURPLE: '#96CEB4',
+  ORANGE: '#FECA57',
+  PINK: '#FF9FF3'
+} as const;
+
+// Default colors for X and O players when no color is selected
+export const DEFAULT_PLAYER_COLORS = {
+  X: PLAYER_COLORS.RED,
+  O: PLAYER_COLORS.BLUE
+} as const;
+
 // Game Configuration
 export const GAME_CONFIG = {
   BOARD_SIZE: {
@@ -159,4 +175,4 @@ export const UI_CONFIG = {
     LG: 1024,
     XL: 1280
   }
-} as const; 
+} as const;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,25 @@
 // Player and Game State Types
+import { PLAYER_COLORS } from './constants';
+
 export type Player = 'X' | 'O';
 export type Cell = Player | null;
 export type Board = Cell[];
+
+export type PlayerColor = typeof PLAYER_COLORS[keyof typeof PLAYER_COLORS];
+
+export interface PlayerColorSelection {
+  playerId: string;
+  color: PlayerColor;
+}
+
+export interface ExtendedPlayer {
+  id: string;
+  name: string;
+  symbol: Player;
+  color: PlayerColor;
+  isReady: boolean;
+  score: number;
+}
 
 export interface GameState {
   id: string;
@@ -22,6 +40,17 @@ export interface GamePlayer {
   symbol: Player;
   isReady: boolean;
   score: number;
+  color?: PlayerColor;
+}
+
+export interface ColorSelectionValidation {
+  isValid: boolean;
+  conflictingPlayerId?: string;
+  availableColors: PlayerColor[];
+}
+
+export interface GameStateWithColors extends GameState {
+  players: ExtendedPlayer[];
 }
 
 export interface GameMove {
@@ -165,4 +194,4 @@ export type DeepPartial<T> = {
   [P in keyof T]?: T[P] extends object ? DeepPartial<T[P]> : T[P];
 };
 
-export type RequiredKeys<T, K extends keyof T> = T & Required<Pick<T, K>>; 
+export type RequiredKeys<T, K extends keyof T> = T & Required<Pick<T, K>>;


### PR DESCRIPTION
## 🎨 Player Color Selection - Shared Types Foundation

This PR implements the foundational types and constants needed for the player color selection feature requested in **WTB-1**.

### 🔧 Changes Made

#### New Constants (`src/constants.ts`)
- `PLAYER_COLORS`: 6 available colors (Red, Blue, Green, Purple, Orange, Pink)
- `DEFAULT_PLAYER_COLORS`: Default colors for X and O players when no selection is made

#### New Types (`src/types.ts`)
- `PlayerColor`: Type-safe color values based on available colors
- `PlayerColorSelection`: Interface for color selection requests
- `ExtendedPlayer`: Enhanced player interface with required color field
- `ColorSelectionValidation`: Interface for color validation responses
- `GameStateWithColors`: Enhanced game state with color information

#### Enhanced Existing Types
- `GamePlayer`: Added optional `color` field for backwards compatibility
- Maintained existing `Player` type ('X' | 'O') for compatibility

### 🔗 Related Repositories
This shared types update enables color selection across:
- Frontend: Color picker UI components
- Game Engine: Color-aware game logic
- Backend: Color validation and storage
- Database Service: Color preference persistence

### ✅ Backwards Compatibility
- All existing types remain unchanged
- New color functionality is additive and optional
- Games without color selection will use default colors

### 🎯 Resolves
- **WTB-1**: Allow players to select their color in tic tac toe

### 🔄 Next Steps
1. Update game engine to handle player colors
2. Add color selection UI to frontend
3. Implement color validation in backend
4. Add color preference storage to database service