### PR TITLE
feat: Add CSV export types for leaderboard functionality (JPA-46)

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,34 @@
+// CSV Export Types
+export interface CSVExportOptions {
+  includeHeaders?: boolean;
+  dateRange?: {
+    startDate: string;
+    endDate: string;
+  };
+  sortBy?: 'wins' | 'totalGames' | 'winRate';
+  sortOrder?: 'asc' | 'desc';
+  limit?: number;
+}
+
+export interface CSVExportResponse {
+  success: boolean;
+  data?: string; // CSV content as string
+  filename?: string;
+  error?: string;
+  timestamp: string;
+}
+
+export interface LeaderboardCSVData {
+  rank: number;
+  username: string;
+  wins: number;
+  losses: number;
+  draws: number;
+  totalGames: number;
+  winRate: string; // Formatted as percentage
+  lastActive: string; // Formatted date string
+}
+
 // Player and Game State Types
 export type Player = 'X' | 'O';
 export type Cell = Player | null;
@@ -165,4 +196,4 @@ export type DeepPartial<T> = {
   [P in keyof T]?: T[P] extends object ? DeepPartial<T[P]> : T[P];
 };
 
-export type RequiredKeys<T, K extends keyof T> = T & Required<Pick<T, K>>; 
+export type RequiredKeys<T, K extends keyof T> = T & Required<Pick<T, K>>;


### PR DESCRIPTION
## Summary
This PR adds TypeScript type definitions to support CSV export functionality for leaderboards as requested in Jira issue JPA-46.

## Changes Made
- **CSVExportOptions**: Configuration interface for CSV export requests with options for headers, date filtering, sorting, and limits
- **CSVExportResponse**: API response interface for CSV export endpoints
- **LeaderboardCSVData**: Formatted data structure for CSV content with user-friendly field names

## Technical Details
- Added types at the top of types.ts file for better organization
- Maintains backward compatibility with existing types
- Supports flexible export options (date ranges, sorting, pagination)
- Uses string formatting for percentage and date fields in CSV output

## Related Issue
- Jira: JPA-46 - Add CSV export functionality for leaderboard

## Next Steps
These types will be used by:
- Database service for data formatting
- Backend API for endpoint definitions  
- Frontend UI for export controls