### PR TITLE
Add CSV export types for leaderboard functionality

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,4 +2,14 @@
 export * from './types';
 
 // Export all constants
-export * from './constants'; 
+export * from './constants';
+
+// CSV Export Types
+export type {
+  CsvExportRequest,
+  CsvExportResponse,
+  CsvColumnConfig,
+  CsvFormatOptions,
+  CsvFieldFormatter,
+  CsvExportStatus
+} from './types';

--- a/src/types.ts
+++ b/src/types.ts
@@ -165,4 +165,51 @@ export type DeepPartial<T> = {
   [P in keyof T]?: T[P] extends object ? DeepPartial<T[P]> : T[P];
 };
 
-export type RequiredKeys<T, K extends keyof T> = T & Required<Pick<T, K>>; 
+export type RequiredKeys<T, K extends keyof T> = T & Required<Pick<T, K>>;
+
+// CSV Export Types
+export interface CsvExportRequest {
+  leaderboardType: 'global' | 'monthly' | 'weekly';
+  dateRange?: {
+    startDate: string;
+    endDate: string;
+  };
+  includeColumns: CsvColumnConfig[];
+  formatOptions?: CsvFormatOptions;
+}
+
+export interface CsvExportResponse {
+  success: boolean;
+  csvData?: string;
+  fileName: string;
+  recordCount: number;
+  error?: string;
+}
+
+export interface CsvColumnConfig {
+  field: keyof LeaderboardEntry | keyof PlayerStats;
+  header: string;
+  enabled: boolean;
+  order: number;
+  formatter?: CsvFieldFormatter;
+}
+
+export interface CsvFormatOptions {
+  delimiter: ',' | ';' | '\t';
+  includeHeaders: boolean;
+  dateFormat: 'ISO' | 'US' | 'EU';
+  numberFormat: 'decimal' | 'integer';
+  encoding: 'UTF-8' | 'UTF-16';
+}
+
+export type CsvFieldFormatter = (value: any) => string;
+
+export interface CsvExportStatus {
+  exportId: string;
+  status: 'pending' | 'processing' | 'completed' | 'failed';
+  progress: number;
+  createdAt: string;
+  completedAt?: string;
+  downloadUrl?: string;
+  error?: string;
+}


### PR DESCRIPTION
This PR adds comprehensive TypeScript interfaces and types to support CSV export functionality for the leaderboard system.

## Changes Made
- **CsvExportRequest**: Interface for CSV export requests with leaderboard type, date range, column configuration
- **CsvExportResponse**: Response structure with success status, CSV data, filename, and record count
- **CsvColumnConfig**: Flexible column configuration allowing custom headers, field selection, and formatting
- **CsvFormatOptions**: Export formatting options including delimiter, date format, encoding
- **CsvExportStatus**: Status tracking for async export operations

## Implementation Details
- Types are designed to work with existing LeaderboardEntry and PlayerStats interfaces
- Supports different leaderboard types (global, monthly, weekly)
- Allows flexible column configuration and formatting options
- Includes error handling and status tracking

This establishes the type foundation for CSV export functionality across the backend and frontend components.

**Related Issue**: JPA-46 - Add CSV export functionality for leaderboard